### PR TITLE
Added some missing commas in the witness graph definition and updated…

### DIFF
--- a/puzzle.py
+++ b/puzzle.py
@@ -7,7 +7,7 @@ class Puzzle:
         for key, value in graph.items():
             for item in value:
                 if 'Exit' in item:
-                    exits += item
+                    exits += key
         return exits
 
     def find_all_paths(self, graph, start, end, path=None):

--- a/test_puzzle.py
+++ b/test_puzzle.py
@@ -47,13 +47,13 @@ class TestPuzzle(unittest.TestCase):
             'e': ['a', 'c', 'b', 'd', 'eExit']
         }
         self.the_witness_seven_nodes_six_exits = {
-            'a': ['b', 'f', 'g' 'aExit'],
-            'b': ['a', 'c', 'g' 'bExit'],
-            'c': ['b', 'd', 'g' 'cExit'],
-            'd': ['c', 'e', 'g' 'dExit'],
-            'e': ['d', 'f', 'g' 'eExit'],
-            'f': ['e', 'a', 'g' 'fExit'],
-            'g': ['a', 'b' 'c', 'd', 'e', 'f']
+            'a': ['b', 'f', 'g', 'aExit'],
+            'b': ['a', 'c', 'g', 'bExit'],
+            'c': ['b', 'd', 'g', 'cExit'],
+            'd': ['c', 'e', 'g', 'dExit'],
+            'e': ['d', 'f', 'g', 'eExit'],
+            'f': ['e', 'a', 'g', 'fExit'],
+            'g': ['a', 'b', 'c', 'd', 'e', 'f']
         }
         self.puzzle = Puzzle()
 
@@ -90,5 +90,5 @@ class TestPuzzle(unittest.TestCase):
             self.five_nodes_five_exits_max_connections)))
 
     def test_solve_the_witness_seven_nodes_six_exits(self):
-        self.assertEqual(116, len(self.puzzle.solve(
+        self.assertEqual(642, len(self.puzzle.solve(
             self.the_witness_seven_nodes_six_exits)))


### PR DESCRIPTION
… the test result.

In puzzle.py, correct the exit finding by adding the key, not (every letter of the) exit node.
This bug was not apparent from the test data due to the naming convention of the exit nodes
(e.g. "aExit") and the fact that no nodes were named 'E', 'x', 'i', or 't'.

(The correct count is 107 for each of 6 exits, and thus 642 total.)